### PR TITLE
Fix wrong version bug

### DIFF
--- a/jvcli/commands/create.py
+++ b/jvcli/commands/create.py
@@ -4,7 +4,7 @@ import os
 
 import click
 
-from jvcli import __supported__jivas__versions__, __version__
+from jvcli import __supported__jivas__versions__
 from jvcli.api import RegistryAPI
 from jvcli.auth import load_token, save_token
 from jvcli.utils import TEMPLATES_DIR, validate_name, validate_snake_case
@@ -370,14 +370,14 @@ def create_agent(
 
     # Load templates
     template_paths = {
-        "info.yaml": os.path.join(TEMPLATES_DIR, __version__, "agent_info.yaml"),
+        "info.yaml": os.path.join(TEMPLATES_DIR, jivas_version, "agent_info.yaml"),
         "descriptor.yaml": os.path.join(
-            TEMPLATES_DIR, __version__, "agent_descriptor.yaml"
+            TEMPLATES_DIR, jivas_version, "agent_descriptor.yaml"
         ),
         "knowledge.yaml": os.path.join(
-            TEMPLATES_DIR, __version__, "agent_knowledge.yaml"
+            TEMPLATES_DIR, jivas_version, "agent_knowledge.yaml"
         ),
-        "memory.yaml": os.path.join(TEMPLATES_DIR, __version__, "agent_memory.yaml"),
+        "memory.yaml": os.path.join(TEMPLATES_DIR, jivas_version, "agent_memory.yaml"),
     }
 
     # Check if all templates exist


### PR DESCRIPTION
## Type of Change
- [x] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request fixes a bug in template path handling in `create.py` by using the `jivas_version` variable instead of `__version__`, ensuring the correct version of templates is selected.

## Description
### Improvements to Template Path Handling
- **Variable Replacement**
  - Updated `jvcli/commands/create.py` to:
    - Remove `__version__` import.
    - Use `jivas_version` for template path resolution.

- **Template Versioning**
  - Ensures that the correct template version is used based on the specified Jivas version.

## Changes Made
1. Removed dependency on `__version__` in `create.py`.
2. Updated template path references to use `jivas_version`.
3. Improved consistency in version handling across the `create_agent` function.
