### PR TITLE
[Feature Request]: Add `--no-env` Flag for StartProject

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 🚀 Features | Bug Fixes 🐛 | Refactor 🔄
+      labels:
+        - '*'

--- a/.github/workflows/release-jvcli.yaml
+++ b/.github/workflows/release-jvcli.yaml
@@ -81,4 +81,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v${{ needs.check-version.outputs.new_version }} dist/* --title "Release v${{ needs.check-version.outputs.new_version }}" --notes "Automated release for version v${{ needs.check-version.outputs.new_version }}."
+          gh release create v${{ needs.check-version.outputs.new_version }} dist/* --title "Release v${{ needs.check-version.outputs.new_version }}" --notes "Automated release for version v${{ needs.check-version.outputs.new_version }}." --generate-notes

--- a/jvcli/__init__.py
+++ b/jvcli/__init__.py
@@ -4,5 +4,5 @@ jvcli package initialization.
 This package provides the CLI tool for Jivas Package Repository.
 """
 
-__version__ = "2.0.15"
+__version__ = "2.0.16"
 __supported__jivas__versions__ = ["2.0.0"]

--- a/jvcli/__init__.py
+++ b/jvcli/__init__.py
@@ -4,5 +4,5 @@ jvcli package initialization.
 This package provides the CLI tool for Jivas Package Repository.
 """
 
-__version__ = "2.0.12"
+__version__ = "2.0.13"
 __supported__jivas__versions__ = ["2.0.0"]

--- a/jvcli/commands/startproject.py
+++ b/jvcli/commands/startproject.py
@@ -16,12 +16,18 @@ from jvcli.utils import TEMPLATES_DIR
     show_default=True,
     help="Jivas project version to use for scaffolding.",
 )
-def startproject(project_name: str, version: str) -> None:
+@click.option(
+    "--no-env",
+    is_flag=True,
+    default=False,
+    help="Skip generating the .env file.",
+)
+def startproject(project_name: str, version: str, no_env: bool) -> None:
     """
     Initialize a new Jivas project with the necessary structure.
 
     Usage:
-        jvcli startproject <project_name> [--version <jivas_version>]
+        jvcli startproject <project_name> [--version <jivas_version>] [--no-env]
     """
 
     template_path = os.path.join(TEMPLATES_DIR, version, "project")
@@ -69,12 +75,13 @@ def startproject(project_name: str, version: str) -> None:
                         gitignore_file.write(contents)
 
                 if file_name == "env.example":
-                    # Write `.env`
-                    target_file_path_env = os.path.join(target_dir, ".env")
-                    with open(target_file_path_env, "w") as env_file:
-                        env_file.write(contents)
+                    # Write `.env` only if no-env flag is not set
+                    if not no_env:
+                        target_file_path_env = os.path.join(target_dir, ".env")
+                        with open(target_file_path_env, "w") as env_file:
+                            env_file.write(contents)
 
-                    # Write `env.example`
+                    # Always write `env.example`
                     target_file_path_example = os.path.join(target_dir, "env.example")
                     with open(target_file_path_example, "w") as example_file:
                         example_file.write(contents)
@@ -83,7 +90,7 @@ def startproject(project_name: str, version: str) -> None:
                     project_file.write(contents)
 
         click.secho(
-            f"Successfully created Jivas project: {project_name} (Version: {version})",
+            f"Successfully created Jivas project: {project_name} (Version: {version}){' (without .env file)' if no_env else ''}",
             fg="green",
         )
 

--- a/jvcli/templates/2.0.0/project/env.example
+++ b/jvcli/templates/2.0.0/project/env.example
@@ -15,6 +15,7 @@ JACPATH="./"
 JIVAS_FILE_INTERFACE="local"
 JIVAS_FILES_ROOT_PATH=".files"
 JIVAS_FILES_URL=http://127.0.0.1:9000/files
+
 # S3 Config
 # JIVAS_S3_ENDPOINT=access_key_id # optional
 # JIVAS_S3_ACCESS_KEY_ID=access_key_id

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "requests>=2.32.3",
         "packaging>=24.2",
         "pyaml>=25.1.0",
-        "jac-cloud>=0.1.19",
+        "jac-cloud==0.1.20",
         "streamlit>=1.42.0",
         "streamlit-elements>=0.1.0",
         "streamlit-router>=0.1.8",


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [x] 🚀 Feature
- [ ] 🔧 Infrastructure
- [ ] 📝 Docs

## Summary

This PR introduces enhancements to the project initialization process, updates release configurations, and bumps a dependency version.

### ✅ What's New

#### 🆕 `startproject` Command
- Added a `--no-env` flag to `jvcli startproject`:
  - Allows users to skip generation of the `.env` file during project initialization.
  - Helps keep project directories clean in CI setups or preconfigured environments.
  - Adjusted output messaging based on whether `.env` is created or skipped.

#### 🛠️ Release Process Enhancements
- Added changelog categories to `.github/release.yml`:
  - Enables automatic grouping of changes into: `Features`, `Bug Fixes`, and `Refactor`.
- Updated the release workflow to include `--generate-notes`:
  - Automates GitHub release note generation for better traceability.

#### 📦 Dependency Updates
- Bumped `jac-cloud` dependency to version `0.1.20` in `setup.py`.

#### 🧼 Minor Improvements
- Added a newline in the `env.example` template for improved readability.

## Impact

- Developers can now use `--no-env` for cleaner project scaffolding.
- Release workflows are more automated and informative.
- Ensures compatibility with the latest `jac-cloud` features.